### PR TITLE
Small documentation improvements

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -344,19 +344,27 @@ Template values:
 - `{{commitMessages}}`: Message of backported commit. For multiple commits the messages will be separated by pipes (`|`).
 - `{{commits}}`: A list of commits ([`Commit` interface](https://github.com/sorenlouv/backport/blob/main/src/lib/sourceCommit/parseSourceCommit.ts))
 
-Default: `"[{{targetBranch}}] {{commitMessages}}"`
+**Default**
 
-**Example: Use original PR title prefixed by branch**
-
+```json
+{
+  "prTitle": "[{{targetBranch}}] {{commitMessages}}"
+}
 ```
-{{targetBranch}} {{sourcePullRequest.title}}
-```
 
-**Example**
+**Example: Slightly more verbose**
 
 ```json
 {
   "prTitle": "{{commitMessages}} backport for {{targetBranch}}"
+}
+```
+
+**Example: Use original PR title prefixed by branch**
+
+```json
+{
+  "prTitle": "{{targetBranch}} {{sourcePullRequest.title}}"
 }
 ```
 

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -340,9 +340,9 @@ Template values:
 
 - `{{sourceBranch}}`: Branch the commit is coming from (usually `main`)
 - `{{targetBranch}}`: Branch the backport PR will be targeting
-- `{{sourcePullRequest}}`: Original pull request object (see [interface](https://github.com/sorenlouv/backport/blob/9e42503a7d0e06e60c575ed2c3b7dc3e5df0dd5c/src/lib/sourceCommit/parseSourceCommit.ts#L23-L31))
+- `{{sourcePullRequest}}`: Original pull request object (see [`Commit` interface](https://github.com/sorenlouv/backport/blob/main/src/lib/sourceCommit/parseSourceCommit.ts))
 - `{{commitMessages}}`: Message of backported commit. For multiple commits the messages will be separated by pipes (`|`).
-- `{{commits}}`: A list of commits ([interface](https://github.com/sorenlouv/backport/blob/9e42503a7d0e06e60c575ed2c3b7dc3e5df0dd5c/src/lib/sourceCommit/parseSourceCommit.ts#L15-L36))
+- `{{commits}}`: A list of commits ([`Commit` interface](https://github.com/sorenlouv/backport/blob/main/src/lib/sourceCommit/parseSourceCommit.ts))
 
 Default: `"[{{targetBranch}}] {{commitMessages}}"`
 
@@ -360,7 +360,7 @@ Default: `"[{{targetBranch}}] {{commitMessages}}"`
 }
 ```
 
-See [source code](https://github.com/sorenlouv/backport/blob/7c998dd05bda06e9979409cc4e63273bad711d11/src/lib/github/v3/createPullRequest.test.ts#L340-L522) for more examples
+See [source code](https://github.com/sorenlouv/backport/blob/main/src/lib/github/v3/createPullRequest.test.ts) for more examples.
 
 #### `prDescription`
 
@@ -371,7 +371,7 @@ The description uses the [handlebars templating engine](https://handlebarsjs.com
 - `{{targetBranch}}`: Branch the backport PR will be targeting
 - `{{commitMessages}}`: Message of backported commit. For multiple commits the messages will be separated by new lines (`|`).
 - `{{defaultPrDescription}}`: The default PR description. Using this makes it easy to append and prepend text to the existing description
-- `{{commits}}`: A list of commit objects (see [commit interface](https://github.com/sorenlouv/backport/blob/9e42503a7d0e06e60c575ed2c3b7dc3e5df0dd5c/src/lib/sourceCommit/parseSourceCommit.ts#L15-L36))
+- `{{commits}}`: A list of commit objects (see [`Commit` interface](https://github.com/sorenlouv/backport/blob/main/src/lib/sourceCommit/parseSourceCommit.ts))
 
 **Example: List commits**
 
@@ -389,7 +389,7 @@ For people who often want to append the same text, they can create a bash alias:
 alias backport-skip-ci='backport --pr-description "{defaultPrDescription} [skip-ci]"'
 ```
 
-See [source code](https://github.com/sorenlouv/backport/blob/7c998dd05bda06e9979409cc4e63273bad711d11/src/lib/github/v3/createPullRequest.test.ts#L340-L522) for more examples
+See [source code](https://github.com/sorenlouv/backport/blob/main/src/lib/github/v3/createPullRequest.test.ts) for more examples.
 
 #### `prFilter`
 
@@ -525,7 +525,7 @@ Branch name to use for the backport PR
 Template values:
 
 - `{{targetBranch}}`: Branch the backport PR will be targeting
-- `{{sourcePullRequest}}`: Original pull request object (see [interface](https://github.com/sorenlouv/backport/blob/9e42503a7d0e06e60c575ed2c3b7dc3e5df0dd5c/src/lib/sourceCommit/parseSourceCommit.ts#L23-L31))
+- `{{sourcePullRequest}}`: Original pull request object (see [`Commit` interface](https://github.com/sorenlouv/backport/blob/main/src/lib/sourceCommit/parseSourceCommit.ts))
 - `{{refValues}}`: Name representing the original commit/PR, `commit-<hash>` or `pr-<pr number>` respectively.
 
 Default: `backport/{{targetBranch}}/{{refValues}}`
@@ -538,4 +538,4 @@ Default: `backport/{{targetBranch}}/{{refValues}}`
 }
 ```
 
-See [source code](https://github.com/sorenlouv/backport/blob/main/src/lib/cherrypickAndCreateTargetPullRequest/getBackportBranchName.ts#L14).
+See [source code](https://github.com/sorenlouv/backport/blob/main/src/lib/cherrypickAndCreateTargetPullRequest/getBackportBranchName.ts).

--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -193,7 +193,7 @@ Default: `backport`
 
 #### `branchLabelMapping`
 
-Automatically detech which branches a pull request should be backported to, based on the pull request labels.
+Automatically detect which branches a pull request should be backported to, based on the pull request labels.
 
 ```json
 {
@@ -409,7 +409,7 @@ Default: `False`
 
 ```json
 {
-  "publishStatusCommentOnSuccess": false
+  "publishStatusCommentOnAbort": false
 }
 ```
 


### PR DESCRIPTION
While setting up the GitHub Action provided by this project I came across some minor papercuts in the documentation that confused me initially.

See the individual commit messages for details.

- **Documentation: Fix typos**
- **Docs: Use main branch links to source code**
- **Docs: Improve consistency in prTitle documentation**
