### PR TITLE
Spawn processes with LANG that's guaranteed to exist

### DIFF
--- a/src/lib/child-process-promisified.ts
+++ b/src/lib/child-process-promisified.ts
@@ -46,8 +46,8 @@ export async function spawnPromise(
     const subprocess = childProcess.spawn(cmd, cmdArgs, {
       cwd,
 
-      // ensure that git commands return english error messages
-      env: { ...process.env, LANG: 'en_US' },
+      // ensure that git commands return English error messages
+      env: { ...process.env, LANG: 'C' },
       ...(isInteractive ? { stdio: 'inherit' } : undefined),
     });
     let stderr = '';
@@ -95,7 +95,7 @@ export const spawnStream = (cmd: string, cmdArgs: ReadonlyArray<string>) => {
   const spawnSpan = startSpawnSpan(cmd, cmdArgs);
 
   const res = childProcess.spawn(cmd, cmdArgs, {
-    env: { ...process.env, LANG: 'en_US' },
+    env: { ...process.env, LANG: 'C' },
   });
 
   res.on('close', (code) => {


### PR DESCRIPTION
`LANG=en_US` is not guaranteed to exist on any system (it does not, for
strange reasons, exist on mine). Choose `LANG=C`, which is guaranteed to
exist. It has the side-effect of typically using an encoding other than
UTF-8 for the tool output (e.g., ISO 8859-1). Apart from messages
printed into the log in this encoding that should hopefully have no
negative side-effects.

See https://github.com/sorenlouv/backport/pull/505 for a case where
code was assuming that output would always be English, and failed if it
wasn't.
