### PR TITLE
Swallow "remote not found" error on git before 2.30

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -191,10 +191,15 @@ export async function deleteRemote(
   } catch (e) {
     const isSpawnError = e instanceof SpawnError;
 
-    // Swallow the "remote does not exist" failure, indicated by a return
-    // code of 2. From `git help remote`: "When subcommands such as add, rename,
-    // and remove can’t find the remote in question, the exit status is 2."
-    if (isSpawnError && e.context.code == 2) {
+    // Swallow the "remote does not exist" failure.
+    // Since git 2.30.0, this failure is indicated by the specific exit code 2.
+    // In earlier versions, the exit code is 128 and only the error message can
+    // tell the problems apart.
+    if (
+      isSpawnError &&
+      (e.context.code == 2 ||
+        (e.context.code == 128 && e.context.stderr.includes('No such remote')))
+    ) {
       return;
     }
 


### PR DESCRIPTION
Git 2.30.0 introduced a dedicated exit code (2) for when `git remote rm`
failed because the remote does not exist. Earlier versions of git
always returned code 128, and only parsing stderr could tell the error
conditions apart.

Support all versions of git by checking for both exit code 2, and exit
code 128 with the specific error message. The exit code 2 check remains
more robust against localized output, hence it's kept in addition to the
output parsing path that was removed in #505.

Fixes #509
