### PR TITLE
Strip markdown comments from stringified commits

### DIFF
--- a/src/lib/github/v3/getPullRequest/getPullRequestBody.test.ts
+++ b/src/lib/github/v3/getPullRequest/getPullRequestBody.test.ts
@@ -99,6 +99,39 @@ text to append"
         );
       });
 
+      it('strips markdown comments', () => {
+        const commits = [
+          {
+            sourcePullRequest: {
+              url: 'https://github.com/backport-org/different-merge-strategies/pull/55',
+            },
+            sourceCommit: {
+              sha: 'acbcdef',
+              message:
+                'My commit message (#55) <!-- markdown-comment --> And then some more text',
+            },
+            sourceBranch: 'main',
+          },
+        ] as Commit[];
+
+        const options = {
+          prDescription: 'Just output the commits: {commits}',
+        } as ValidConfigOptions;
+
+        const res = getPullRequestBody({
+          options,
+          commits,
+          targetBranch: '7.x',
+        });
+
+        expect(res).not.toContain('markdown-comment');
+        expect(res).not.toContain('<!--');
+        expect(res).not.toContain('-->');
+        expect(res).toContain(
+          'My commit message (#55)  And then some more text',
+        );
+      });
+
       it('handles curly brackets in commit messages without error', () => {
         const commits = [
           {

--- a/src/lib/github/v3/getPullRequest/getPullRequestBody.ts
+++ b/src/lib/github/v3/getPullRequest/getPullRequestBody.ts
@@ -37,7 +37,9 @@ export function getPullRequestBody({
     '### Questions ?\n' +
     'Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)';
 
-  const commitsStringified = `{{{{raw}}}}${JSON.stringify(commits)}{{{{/raw}}}}`;
+  const commitsStringified = stripMarkdownComments(
+    `{{{{raw}}}}${JSON.stringify(commits)}{{{{/raw}}}}`,
+  );
 
   const prDescription = (options.prDescription ?? defaultPrDescription)
 
@@ -78,4 +80,8 @@ export function getPullRequestBody({
       .replaceAll('{{{{raw}}}}', '')
       .replaceAll('{{{{/raw}}}}', '');
   }
+}
+
+function stripMarkdownComments(str: string): string {
+  return str.replace(/<!--[\s\S]*?-->/g, '');
 }


### PR DESCRIPTION
Follow up to #526 

This strips markdown comments like `<!-- markdown-comment -->`  in the stringified commit message `{{commitsStringified}}`