### PR TITLE
Allow configuring RegEx patterns for `copySourcePRLabels`

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -490,11 +490,15 @@ Assign the same reviewers to the target pull request that were assigned to the o
 
 #### `copySourcePRLabels`
 
-Copies all labels from the original (source) pull request to the backport (target) pull request.
+Copies labels from the original (source) pull request to the backport (target) pull request.
+Can be either a boolean or an array of strings. When set to `true`, _all_ labels from the source PR are copied to the target PR.
+When an array of strings is configured, each string is used as a RegEx pattern and will be compared to each label of the source PR.
+If the label on the source PR matches at least one configured string, it will be copied to the target PR.
 
+Default: `false`
 ```json
 {
-  "copySourcePRLabels": false
+  "copySourcePRLabels": ["^Team:.*", "^:.*", "^>.*"]
 }
 ```
 

--- a/src/options/ConfigOptions.ts
+++ b/src/options/ConfigOptions.ts
@@ -31,7 +31,7 @@ type Options = Partial<{
   cherrypickRef: boolean;
   commitConflicts: boolean;
   commitPaths: string[];
-  copySourcePRLabels: boolean;
+  copySourcePRLabels: boolean | string[];
   copySourcePRReviewers: boolean;
   details: boolean;
   dir: string;


### PR DESCRIPTION
Currently, we only allow copying over either all or no labels. With this commit, we also allow specifying a list of RegEx patterns that will be used to conditionally copy over labels.

This is useful when you don't want to copy over all labels, but you also don't want to manually specify every time which labels you want to be copied over.