### PR TITLE
Fix Jest config file imports for Jest v30 ESM compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.env
 /src/graphql
 /.eslintcache
+/.tsbuildinfo

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ module.exports = [
       'src/graphql/generated/**',
       'bin/**',
       'coverage/**',
+      '.tsbuildinfo/**',
     ],
   },
 
@@ -57,9 +58,48 @@ module.exports = [
     ...js.configs.recommended,
   },
 
+  // Jest config files - use separate tsconfig that allows .ts extensions
+  {
+    files: ['jest.config*.ts'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parser: tsparser,
+      parserOptions: {
+        project: './tsconfig.jest-config.json',
+      },
+      globals: nodeGlobals,
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      import: importPlugin,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...tseslint.configs.recommended.rules,
+      'import/order': [
+        'error',
+        {
+          alphabetize: { order: 'asc' },
+          'newlines-between': 'never',
+          groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        },
+      ],
+      'import/no-duplicates': 'error',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/prefer-nullish-coalescing': 'error',
+      '@typescript-eslint/prefer-optional-chain': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      'no-unused-vars': 'off',
+    },
+  },
+
   // TypeScript files
   {
     files: ['**/*.ts'],
+    ignores: ['jest.config*.ts'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/jest.config.all.ts
+++ b/jest.config.all.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-config-loader-options {"compilerOptions":{"allowImportingTsExtensions":true}}
+ */
 import type { Config } from 'jest';
 import baseConfig from './jest.config.ts';
 

--- a/jest.config.all.ts
+++ b/jest.config.all.ts
@@ -1,6 +1,7 @@
-import baseConfig from './jest.config';
+import type { Config } from 'jest';
+import baseConfig from './jest.config.ts';
 
-const config = {
+const config: Config = {
   ...baseConfig,
   modulePathIgnorePatterns: [],
 };

--- a/jest.config.mutation.ts
+++ b/jest.config.mutation.ts
@@ -1,6 +1,7 @@
-import baseConfig from './jest.config';
+import type { Config } from 'jest';
+import baseConfig from './jest.config.ts';
 
-const config = {
+const config: Config = {
   ...baseConfig,
 
   // only include "mutation" tests that cannot run on in parallel (like they are on CI) because they mutate shared state

--- a/jest.config.mutation.ts
+++ b/jest.config.mutation.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-config-loader-options {"compilerOptions":{"allowImportingTsExtensions":true}}
+ */
 import type { Config } from 'jest';
 import baseConfig from './jest.config.ts';
 

--- a/jest.config.private.ts
+++ b/jest.config.private.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-config-loader-options {"compilerOptions":{"allowImportingTsExtensions":true}}
+ */
 import type { Config } from 'jest';
 import baseConfig from './jest.config.ts';
 

--- a/jest.config.private.ts
+++ b/jest.config.private.ts
@@ -1,6 +1,7 @@
-import baseConfig from './jest.config';
+import type { Config } from 'jest';
+import baseConfig from './jest.config.ts';
 
-const config = {
+const config: Config = {
   ...baseConfig,
 
   // only include (private) tests that cannot run on CI because they require credentials and thus exclude external contributors

--- a/tsconfig.jest-config.json
+++ b/tsconfig.jest-config.json
@@ -1,22 +1,11 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "lib": ["ES2021", "DOM"],
-    "module": "CommonJS",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "esModuleInterop": true,
-    "useUnknownInCatchVariables": true,
-    "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
-    "emitDeclarationOnly": true,
     "composite": true,
+    "emitDeclarationOnly": true,
     "outDir": "./.tsbuildinfo/jest-config"
   },
-  "include": ["jest.config*.ts"]
+  "include": ["jest.config*.ts"],
+  "exclude": []
 }

--- a/tsconfig.jest-config.json
+++ b/tsconfig.jest-config.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "CommonJS",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "useUnknownInCatchVariables": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "outDir": "./.tsbuildinfo/jest-config"
+  },
+  "include": ["jest.config*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "references": [
+    { "path": "./tsconfig.jest-config.json" }
+  ],
   "plugins": [
     {
       "name": "@0no-co/graphqlsp",
@@ -6,12 +9,12 @@
     }
   ],
   "include": ["src/**/*"],
-  "exclude": ["src/graphql/generated/graphql.ts"],
+  "exclude": ["src/graphql/generated/graphql.ts", "jest.config*.ts"],
   "compilerOptions": {
     "declaration": true,
     "target": "ES2021",
     "lib": [
-      "ES2021", 
+      "ES2021",
       "DOM" // needed by wonka
     ],
     "module": "CommonJS",
@@ -29,6 +32,6 @@
     "esModuleInterop": true,
     "useUnknownInCatchVariables": true,
     "sourceMap": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Summary
Fixes Jest config file imports to work with Jest v30's ESM requirements. Jest v30 switched to using Node's native ESM loader for config files, which requires explicit file extensions in imports.

## The Problem
The `test-all`, `test-mutation`, and `test-private` scripts were failing with:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module './jest.config' imported from jest.config.all.ts
```

Jest v30 config files are now loaded by Node's ESM loader, which requires explicit `.ts` extensions, but TypeScript doesn't allow `.ts` extensions in imports by default.

## The Solution

### How Jest v30 Loads TypeScript Config Files

When Jest v30 encounters a TypeScript config file (e.g., `jest.config.private.ts`), it uses **ts-node** internally to compile it. However, ts-node is registered with these default options:

```javascript
tsLoader.register({
  compilerOptions: {
    module: 'CommonJS'
  },
  moduleTypes: {
    '**': 'cjs'
  }
})
```

This forces all files to be treated as CommonJS, which doesn't allow `.ts` extensions in imports without `allowImportingTsExtensions` enabled.

### The Fix: Jest Docblock Pragma

Jest supports passing custom options to ts-node via the `@jest-config-loader-options` docblock pragma. By adding this to config files that import other `.ts` files:

```typescript
/**
 * @jest-config-loader-options {"compilerOptions":{"allowImportingTsExtensions":true}}
 */
import baseConfig from './jest.config.ts';
```

This tells ts-node to enable `allowImportingTsExtensions` when compiling these specific config files, allowing the `.ts` extension imports to work correctly.

### Why This Works Across All Node Versions

- **Node < 22.18.0**: Relies on ts-node with the docblock pragma configuration
- **Node >= 22.18.0**: Can use native TypeScript support, but the docblock pragma is harmless and ensures backward compatibility

## Changes
- ✅ Added `@jest-config-loader-options` docblock pragma to `jest.config.all.ts`, `jest.config.mutation.ts`, and `jest.config.private.ts`
- ✅ Updated config files to use explicit `.ts` extensions in imports
- ✅ Created `tsconfig.jest-config.json` for IDE support (TypeScript project references)
- ✅ Configured ESLint to handle Jest config files separately
- ✅ Added `.tsbuildinfo/` to `.gitignore`

## Benefits
- ✅ All test scripts work: `test-all`, `test-mutation`, `test-private`
- ✅ Compatible with all Node 22.x versions (tested with 22.17.1 and 22.20.0)
- ✅ Full IDE support via TypeScript project references
- ✅ Proper type checking for all files
- ✅ Clean, maintainable solution without workarounds

## Technical Notes
- Uses Jest's built-in docblock pragma support for ts-node configuration
- Only Jest **config** files need `.ts` extensions (not test files - those use ts-jest)
- Test files continue using traditional imports without extensions
- The `tsconfig.jest-config.json` provides IDE support but isn't used by Jest at runtime

## Testing
```bash
# Verify all test scripts can load their configs and find tests
yarn test-all --listTests       # Should find ~65 test files
yarn test-mutation --listTests  # Should find 3 mutation test files  
yarn test-private --listTests   # Should find 28 private test files

# Verify linting and type checking still work
yarn lint                        # Should pass
npx tsc --build                  # Should build successfully
```

Tested with:
- ✅ Node 22.17.1 (without native TS support)
- ✅ Node 22.20.0 (with native TS support)